### PR TITLE
Fix footer line and autoloads

### DIFF
--- a/nyan-prompt.el
+++ b/nyan-prompt.el
@@ -5,12 +5,17 @@
 ;;; Version: 20130721
 ;;; Keywords: nyan, cat, lulz, eshell, rainbow
 
-;;; Inspired by from Jacek "TeMPOraL" Zlydach nyan-mode, to make Porter happy.
+;;; Commentary:
+
+;; Usage: (add-hook 'eshell-load-hook 'nyan-prompt-enable)
+
+;; Inspired by from Jacek "TeMPOraL" Zlydach nyan-mode, to make Porter happy.
 
 
-;;; License:
-;;; Copying is an act of love, please copy. ♡
-;;; The xpm taken awesome nyan-mode
+;; Copying is an act of love, please copy. ♡
+;; The xpm taken awesome nyan-mode
+
+;;; Code:
 
 (defconst +nyan-prompt-dir+ (file-name-directory
                              (or load-file-name buffer-file-name)))
@@ -26,6 +31,7 @@
   (propertize +nyan-prompt-nyan-cat-emoticon+
               'display +nyan-prompt-nyan-cat-image+))
 
+;;;###autoload
 (defun nyan-prompt-enable ()
   (setq eshell-prompt-function
         (lambda nil
@@ -43,7 +49,6 @@
                  (or "#" "~=[,,_,,]:3")
                  " "))))
 
-(add-hook 'eshell-load-hook 'nyan-prompt-enable)
 
 (provide 'nyan-prompt)
-;;; nyan-mode.el
+;;; nyan-mode.el ends here


### PR DESCRIPTION
- Fixed footer line for package.el compatibility
- Don't automatically alter eshell hook: this is bad practice
- Update documentation to describe use of hook

See milkypostman/melpa#905

Further, I'd suggest that you remove the `+` from the `+blah-blah+` variable names: it is more idiomatic in elisp to use a consistent prefix for identifiers in a package, any `nyan-prompt-` is fine for that. Occasionally, a double-dash is used to denote private identifiers, e.g. `nyan-prompt--nyan-cat-emoticon` or `nyan-prompt/nyan-cat-emoticon`.
